### PR TITLE
Merge staging into main

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -23,7 +23,10 @@ export const getUserProfile = async (req, res, next) => {
     }
 
     try {
-        const user = await usersService.getUserById(req.user.id);
+        const [user, timeSpent] = await Promise.all([
+            usersService.getUserById(req.user.id),
+            usersService.getTotalListeningTime(req.user.id),
+        ]);
         if (!user) {
             return res.status(404).json({ error: "User not found" });
         }
@@ -34,7 +37,7 @@ export const getUserProfile = async (req, res, next) => {
             username: req.user.username,
             sessionStartTime: req.user.sessionStartTime,
             lastActivity: req.user.lastActivity,
-            timeSpent: req.user.timeSpent,
+            timeSpent,
             subscribed: req.user.subscribed,
             email: req.user.email
         });

--- a/backend/controllers/usersController.js
+++ b/backend/controllers/usersController.js
@@ -21,15 +21,9 @@ export const updateUserActivity = async (req, res, next) => {
         const deltaTime = computeTimeSpent(lastRecordedActivity, lastActivityTime);
 
         req.user.lastActivity = lastActivityTime;
-        req.user.timeSpent = (req.user.timeSpent || 0) + deltaTime;
 
-        // TODO: users.time_spent duplicates the SUM of listening_time.time_spent.
-        // Consider dropping users.time_spent and computing the total from listening_time instead.
         const [updatedUser] = await Promise.all([
-            usersService.updateUser(userId, {
-                lastActivityTime,
-                timeSpent: req.user.timeSpent
-            }),
+            usersService.updateUser(userId, { lastActivityTime }),
             channel ? upsertListeningTime(userId, channel, deltaTime) : Promise.resolve(),
         ]);
 

--- a/backend/loaders/passportLoader.js
+++ b/backend/loaders/passportLoader.js
@@ -1,7 +1,7 @@
 import GoogleStrategy from "passport-google-oauth20";
 import passport from "passport";
 import { createGoogleCredential, getGoogleCredential } from "../services/fedCredService.js";
-import { getUserById } from "../services/usersService.js";
+import { getUserById, getTotalListeningTime } from "../services/usersService.js";
 
 const passportLoader = (app) => {
     app.use(passport.initialize());
@@ -24,33 +24,33 @@ const passportLoader = (app) => {
             if (!credentials) {
                 // User does not exist, create one
                 const { id } = await createGoogleCredential(profile);
-                const newUser = await getUserById(id);
+                const [newUser, timeSpent] = await Promise.all([getUserById(id), getTotalListeningTime(id)]);
                 return cb(null, {
                     id: newUser.id,
                     username: newUser.username,
                     role: newUser.role,
                     sessionStartTime: newUser.session_start_time,
                     lastActivity: newUser.last_activity_time,
-                    timeSpent: newUser.time_spent,
+                    timeSpent,
                     subscribed: newUser.subscribed,
                     email: newUser.email,
                 });
             } else {
                 // User exists, fetch their info
                 const userId = credentials.user_id
-                const existingUser = await getUserById(userId);
+                const [existingUser, timeSpent] = await Promise.all([getUserById(userId), getTotalListeningTime(userId)]);
 
                 if (!existingUser) {
                     console.log("User not found in users table.");
                     return cb(null, false);
                 }
-                return cb(null, { 
+                return cb(null, {
                     id: existingUser.id,
                     username: existingUser.username,
                     role: existingUser.role,
                     sessionStartTime: existingUser.session_start_time,
                     lastActivity: existingUser.last_activity_time,
-                    timeSpent: existingUser.time_spent,
+                    timeSpent,
                     subscribed: existingUser.subscribed,
                     email: existingUser.email,
                 });

--- a/backend/repositories/usersRepository.js
+++ b/backend/repositories/usersRepository.js
@@ -88,6 +88,16 @@ export const getListeningTimesByUser = async (userId) => {
     return rows;
 };
 
+export const getTotalListeningTime = async (userId) => {
+    const query = `
+        SELECT COALESCE(SUM(time_spent), 0) AS total
+        FROM listening_time
+        WHERE user_id = $1;
+    `;
+    const { rows } = await db.query(query, [userId]);
+    return parseInt(rows[0].total, 10);
+};
+
 export const upsertListeningTime = async (userId, channel, delta) => {
     const query = `
         INSERT INTO listening_time (user_id, channel, time_spent)

--- a/backend/services/channelCreationService/trackProcessingService.js
+++ b/backend/services/channelCreationService/trackProcessingService.js
@@ -20,7 +20,7 @@ export const processTracks = async ({ tracks, channelName }) => {
     let encodePromise = encodeTrack(startIndex, tracks, channelName);
 
     for (let index = startIndex; index < tracks.length; index++) {
-        console.log(`[${new Date().toISOString().substring(11, 19)}] Processing track ${index + 1} of ${tracks.length}…`);
+        console.log(`[${new Date().toLocaleTimeString('en-GB')}] Processing track ${index + 1} of ${tracks.length}…`);
 
         // Wait for current track's encoding to finish
         const trackMpdPath = await encodePromise;
@@ -45,7 +45,7 @@ export const processTracks = async ({ tracks, channelName }) => {
 };
 
 export const uploadTrackSegments = async (channelName, trackIndex, concurrency = 4) => {
-    console.log(`[${new Date().toISOString().substring(11, 19)}] Uploading segments for track ${trackIndex + 1}…`);
+    console.log(`[${new Date().toLocaleTimeString('en-GB')}] Uploading segments for track ${trackIndex + 1}…`);
     const segments = await getAllTrackSegments(channelName, trackIndex);
     const results = [];
 
@@ -95,7 +95,7 @@ const createProgressLogger = (total, step = 100) => {
     return () => {
         completed++;
         if (completed % step === 0 || completed === total) {
-            console.log(`[${new Date().toISOString().substring(11, 19)}] Uploaded ${completed}/${total} segments`);
+            console.log(`[${new Date().toLocaleTimeString('en-GB')}] Uploaded ${completed}/${total} segments`);
         }
     };
 };

--- a/backend/services/channelCreationService/trackProcessingService.js
+++ b/backend/services/channelCreationService/trackProcessingService.js
@@ -20,7 +20,7 @@ export const processTracks = async ({ tracks, channelName }) => {
     let encodePromise = encodeTrack(startIndex, tracks, channelName);
 
     for (let index = startIndex; index < tracks.length; index++) {
-        console.log(`Processing track ${index + 1} of ${tracks.length}…`);
+        console.log(`[${new Date().toISOString().substring(11, 19)}] Processing track ${index + 1} of ${tracks.length}…`);
 
         // Wait for current track's encoding to finish
         const trackMpdPath = await encodePromise;
@@ -45,7 +45,7 @@ export const processTracks = async ({ tracks, channelName }) => {
 };
 
 export const uploadTrackSegments = async (channelName, trackIndex, concurrency = 4) => {
-    console.log(`Uploading segments for track ${trackIndex + 1}…`);
+    console.log(`[${new Date().toISOString().substring(11, 19)}] Uploading segments for track ${trackIndex + 1}…`);
     const segments = await getAllTrackSegments(channelName, trackIndex);
     const results = [];
 
@@ -95,7 +95,7 @@ const createProgressLogger = (total, step = 100) => {
     return () => {
         completed++;
         if (completed % step === 0 || completed === total) {
-            console.log(`Uploaded ${completed}/${total} segments`);
+            console.log(`[${new Date().toISOString().substring(11, 19)}] Uploaded ${completed}/${total} segments`);
         }
     };
 };

--- a/backend/services/trackEncodingService.js
+++ b/backend/services/trackEncodingService.js
@@ -6,21 +6,39 @@ import { localTrackDirectoryFor, ensureDirectoryExists } from "./channelCreation
 
 const unlink = util.promisify(fs.unlink);
 
+const getTrackDuration = (trackUrl) =>
+  new Promise((resolve, reject) => {
+    ffmpeg.ffprobe(trackUrl, (err, metadata) => {
+      if (err) return reject(err);
+      resolve(metadata.format.duration ?? 0);
+    });
+  });
+
 export const encodeTrack = async (index, playlist, channelName) => {
   const trackDirectory = localTrackDirectoryFor(channelName, index);
   await ensureDirectoryExists(trackDirectory);
   const currentTrack = playlist[index];
   const playlistPath = `${trackDirectory}/track${index}.mpd`;
 
+  const duration = await getTrackDuration(currentTrack);
+  // loudnorm needs sufficient audio to measure integrated loudness; skip it for very short clips
+  const useLoudnorm = duration >= 2;
+
   return new Promise((resolve, reject) => {
+    const stderrLines = [];
     const command = ffmpeg()
       .input(currentTrack)
       .output(playlistPath)
       .noVideo()
       .audioCodec('aac')
       .audioBitrate('320k')
-      .audioFilters('loudnorm=I=-14:TP=-1:LRA=11')
-      .format('dash')
+      .format('dash');
+
+    if (useLoudnorm) {
+      command.audioFilters('loudnorm=I=-14:TP=-1:LRA=11');
+    }
+
+    command
       .outputOptions([
         '-y',                           // Overwrite output files without asking
         '-dash_segment_type', 'mp4',     // Use MP4 segments
@@ -29,8 +47,10 @@ export const encodeTrack = async (index, playlist, channelName) => {
         '-init_seg_name', `track${index}_init.mp4`,  // Name for the initialization segment
         '-media_seg_name', `track${index}_$Number$.m4s`,  // Template for media segments
       ])
+      .on('stderr', (line) => stderrLines.push(line))
       .on('error', (err) => {
-        console.error('FFmpeg error:', err.message);
+        console.error(`FFmpeg error on track ${index}:`, err.message);
+        console.error('FFmpeg stderr:\n' + stderrLines.slice(-20).join('\n'));
         reject(err);
       })
       .on('end', () => {

--- a/backend/services/usersService.js
+++ b/backend/services/usersService.js
@@ -57,6 +57,10 @@ export const getListeningTimesByUser = async (userId) => {
     return await usersRepository.getListeningTimesByUser(userId);
 };
 
+export const getTotalListeningTime = async (userId) => {
+    return await usersRepository.getTotalListeningTime(userId);
+};
+
 export const getUserRankAndTotal = async (id) => {
     const result = await usersRepository.getUserRankAndTotal(id);
     if (!result) {

--- a/backend/tests/loaders/passportLoader.test.js
+++ b/backend/tests/loaders/passportLoader.test.js
@@ -60,6 +60,7 @@ describe('Google OAuth verify callback — new user', () => {
         fedCredService.getGoogleCredential.mockResolvedValue(null);
         fedCredService.createGoogleCredential.mockResolvedValue({ id: 1 });
         usersService.getUserById.mockResolvedValue(mockFullUser);
+        usersService.getTotalListeningTime.mockResolvedValue(0);
 
         const cb = vi.fn();
         await capturedVerify(null, null, mockProfile, cb);
@@ -83,6 +84,7 @@ describe('Google OAuth verify callback — returning user', () => {
     it('fetches existing user by credential user_id and calls cb with the complete object', async () => {
         fedCredService.getGoogleCredential.mockResolvedValue({ user_id: 1 });
         usersService.getUserById.mockResolvedValue(mockFullUser);
+        usersService.getTotalListeningTime.mockResolvedValue(0);
 
         const cb = vi.fn();
         await capturedVerify(null, null, mockProfile, cb);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -56,7 +56,7 @@ export default defineConfig({
                 short_name: 'Coudradio',
                 description: 'Radio streaming',
                 theme_color: '#041C32',
-                background_color: '#041C32',
+                background_color: '#ffffff',
                 display: 'standalone',
                 start_url: '/',
                 icons: [

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -56,7 +56,7 @@ export default defineConfig({
                 short_name: 'Coudradio',
                 description: 'Radio streaming',
                 theme_color: '#041C32',
-                background_color: '#ffffff',
+                background_color: '#041C32',
                 display: 'standalone',
                 start_url: '/',
                 icons: [


### PR DESCRIPTION
## Summary

- Skip loudnorm filter for tracks shorter than 2 seconds
- Add `getTotalListeningTime` repo + service; compute `timeSpent` as a live SUM on profile fetch; stop writing stale value on activity update
- Set PWA `background_color` and splash screen background to dark blue
- Add timestamps to create-channel log lines

## Test plan

- [ ] Verify short tracks (< 2s) encode without errors
- [ ] Confirm total listening time displays correctly on the stats page
- [ ] Confirm PWA splash screen and theme color show dark blue on mobile
- [ ] Confirm create-channel logs include timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)